### PR TITLE
Update SHA3 Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For learning more about Saber, follow their website @ https://www.esat.kuleuven.
 
 ```bash
 $ g++ --version
-g++ (Ubuntu 12.2.0-17ubuntu1) 12.2.0
+g++ (Ubuntu 13.1.0-2ubuntu2~23.04) 13.1.0
 
 $ clang++ --version
 Ubuntu clang version 16.0.0 (1~exp5ubuntu3)
@@ -84,9 +84,9 @@ make -j $(nproc --all)
 [ RUN      ] SaberKEM.LightSaberKnownAnswerTests
 [       OK ] SaberKEM.LightSaberKnownAnswerTests (19 ms)
 [ RUN      ] SaberKEM.SaberKnownAnswerTests
-[       OK ] SaberKEM.SaberKnownAnswerTests (36 ms)
+[       OK ] SaberKEM.SaberKnownAnswerTests (37 ms)
 [ RUN      ] SaberKEM.FireSaberKnownAnswerTests
-[       OK ] SaberKEM.FireSaberKnownAnswerTests (59 ms)
+[       OK ] SaberKEM.FireSaberKnownAnswerTests (60 ms)
 [ RUN      ] SaberKEM.LightSaberPublicKeyEncryption
 [       OK ] SaberKEM.LightSaberPublicKeyEncryption (0 ms)
 [ RUN      ] SaberKEM.SaberPublicKeyEncryption
@@ -97,10 +97,10 @@ make -j $(nproc --all)
 [       OK ] SaberKEM.PolynomialMatrixConversion (0 ms)
 [ RUN      ] SaberKEM.PolynomialConversion
 [       OK ] SaberKEM.PolynomialConversion (0 ms)
-[----------] 11 tests from SaberKEM (116 ms total)
+[----------] 11 tests from SaberKEM (119 ms total)
 
 [----------] Global test environment tear-down
-[==========] 11 tests from 1 test suite ran. (116 ms total)
+[==========] 11 tests from 1 test suite ran. (119 ms total)
 [  PASSED  ] 11 tests.
 ```
 
@@ -120,55 +120,55 @@ make perf       # Must do if you have built google-benchmark library with libPFM
 ### On 12th Gen Intel(R) Core(TM) i7-1260P ( compiled with Clang-16.0 )
 
 ```bash
-2023-08-02T20:43:41+04:00
+2023-08-15T17:42:17+04:00
 Running ./benchmarks/perf.out
-Run on (16 X 1038.99 MHz CPU s)
+Run on (16 X 4709.07 MHz CPU s)
 CPU Caches:
   L1 Data 48 KiB (x8)
   L1 Instruction 32 KiB (x8)
   L2 Unified 1280 KiB (x8)
   L3 Unified 18432 KiB (x1)
-Load Average: 0.73, 0.57, 0.31
+Load Average: 0.74, 0.60, 0.62
 ***WARNING*** There are 9 benchmarks with threads and 1 performance counters were requested. Beware counters will reflect the combined usage across all threads.
 ----------------------------------------------------------------------------------------
 Benchmark                  Time             CPU   Iterations     CYCLES items_per_second
 ----------------------------------------------------------------------------------------
-lightsaber/keygen       15.9 us         15.9 us        44209    74.161k       62.9147k/s
-lightsaber/encaps       23.3 us         23.3 us        30047   108.713k       42.9518k/s
-lightsaber/decaps       28.6 us         28.6 us        24575   133.342k       35.0179k/s
-saber/keygen            33.0 us         33.0 us        21126   154.265k       30.2664k/s
-saber/encaps            45.5 us         45.6 us        15320   212.825k       21.9538k/s
-saber/decaps            52.2 us         52.2 us        13547   241.843k       19.1717k/s
-firesaber/keygen        60.4 us         60.5 us        11621   281.552k       16.5417k/s
-firesaber/encaps        71.3 us         71.3 us         9854   332.447k       14.0283k/s
-firesaber/decaps        83.9 us         83.9 us         8374    391.38k       11.9164k/s
+lightsaber/keygen       24.4 us         24.4 us        28709   114.429k       40.9108k/s
+lightsaber/encaps       35.3 us         35.3 us        19847   164.976k       28.3529k/s
+lightsaber/decaps       37.7 us         37.7 us        18586   176.386k       26.5178k/s
+saber/keygen            50.1 us         50.1 us        10000   233.818k       19.9749k/s
+saber/encaps            64.7 us         64.7 us        10834   302.231k       15.4539k/s
+saber/decaps            67.2 us         67.2 us        10419   313.642k       14.8837k/s
+firesaber/keygen        80.7 us         80.7 us         8625   377.135k        12.394k/s
+firesaber/encaps        98.8 us         98.8 us         7084   462.232k       10.1164k/s
+firesaber/decaps         105 us          105 us         6698   489.383k       9.55764k/s
 ```
 
-### On 12th Gen Intel(R) Core(TM) i7-1260P ( compiled with GCC-12.2 )
+### On 12th Gen Intel(R) Core(TM) i7-1260P ( compiled with GCC-13.1 )
 
 ```bash
-2023-08-02T20:45:14+04:00
+2023-08-15T17:40:13+04:00
 Running ./benchmarks/perf.out
-Run on (16 X 4661.29 MHz CPU s)
+Run on (16 X 2500 MHz CPU s)
 CPU Caches:
   L1 Data 48 KiB (x8)
   L1 Instruction 32 KiB (x8)
   L2 Unified 1280 KiB (x8)
   L3 Unified 18432 KiB (x1)
-Load Average: 0.46, 0.54, 0.32
+Load Average: 0.48, 0.54, 0.60
 ***WARNING*** There are 9 benchmarks with threads and 1 performance counters were requested. Beware counters will reflect the combined usage across all threads.
 ----------------------------------------------------------------------------------------
 Benchmark                  Time             CPU   Iterations     CYCLES items_per_second
 ----------------------------------------------------------------------------------------
-lightsaber/keygen       32.9 us         32.9 us        21197   153.732k       30.4171k/s
-lightsaber/encaps       48.5 us         48.5 us        14478   226.064k       20.6292k/s
-lightsaber/decaps       61.6 us         61.6 us        11349   288.259k       16.2315k/s
-saber/keygen            69.6 us         69.6 us        10106   324.865k       14.3671k/s
-saber/encaps            92.6 us         92.6 us         7594   431.568k       10.8002k/s
-saber/decaps             112 us          112 us         6177   521.694k       8.96309k/s
-firesaber/keygen         123 us          123 us         5709   571.835k       8.15302k/s
-firesaber/encaps         153 us          153 us         4603   711.865k       6.55279k/s
-firesaber/decaps         179 us          179 us         3922   835.373k       5.60172k/s
+lightsaber/keygen       42.7 us         42.7 us        16448   199.181k       23.4172k/s
+lightsaber/encaps       62.4 us         62.4 us        11213   291.544k       16.0302k/s
+lightsaber/decaps       79.5 us         79.5 us         8827   371.144k       12.5831k/s
+saber/keygen            90.5 us         90.5 us         7755   423.147k       11.0511k/s
+saber/encaps             120 us          120 us         5817   560.616k       8.33287k/s
+saber/decaps             146 us          146 us         4824   679.251k       6.87212k/s
+firesaber/keygen         159 us          159 us         4394   742.446k       6.29437k/s
+firesaber/encaps         198 us          198 us         3541   924.359k       5.06157k/s
+firesaber/decaps         232 us          232 us         3010   1083.93k       4.31128k/s
 ```
 
 ## Usage

--- a/include/kem.hpp
+++ b/include/kem.hpp
@@ -52,10 +52,10 @@ keygen(
   std::memcpy(sk_pk.data(), pkey.data(), pkey.size());
 
   // step 2
-  sha3_256::sha3_256 hasher;
-  hasher.absorb(sk_pk.data(), sk_pk.size());
+  sha3_256::sha3_256_t hasher;
+  hasher.absorb(sk_pk);
   hasher.finalize();
-  hasher.digest(sk_hpk.data()); // step 4 ( partial )
+  hasher.digest(sk_hpk); // step 4 ( partial )
   hasher.reset();
 
   // step 4 ( partial )
@@ -86,24 +86,24 @@ encaps(std::span<const uint8_t, keyBytes> m, // step 1
   std::array<uint8_t, sha3_256::DIGEST_LEN> r_prm;
 
   // step 2
-  sha3_256::sha3_256 h256;
-  h256.absorb(m.data(), m.size());
+  sha3_256::sha3_256_t h256;
+  h256.absorb(m);
   h256.finalize();
-  h256.digest(hashed_m.data());
+  h256.digest(hashed_m);
   h256.reset();
 
   // step 3
-  h256.absorb(pkey.data(), pkey.size());
+  h256.absorb(pkey);
   h256.finalize();
-  h256.digest(hashed_pk.data());
+  h256.digest(hashed_pk);
   h256.reset();
 
   // step 4, 5
-  sha3_512::sha3_512 h512;
-  h512.absorb(hashed_m.data(), hashed_m.size());
-  h512.absorb(hashed_pk.data(), hashed_pk.size());
+  sha3_512::sha3_512_t h512;
+  h512.absorb(hashed_m);
+  h512.absorb(hashed_pk);
   h512.finalize();
-  h512.digest(rk.data());
+  h512.digest(rk);
   h512.reset();
 
   // step 6
@@ -116,16 +116,16 @@ encaps(std::span<const uint8_t, keyBytes> m, // step 1
   saber_pke::encrypt<L, EQ, EP, ET, MU>(_hm, _r, pkey, ctxt);
 
   // step 8
-  h256.absorb(ctxt.data(), ctxt.size());
+  h256.absorb(ctxt);
   h256.finalize();
-  h256.digest(r_prm.data());
+  h256.digest(r_prm);
   h256.reset();
 
   // step 9, 10
-  h256.absorb(k.data(), k.size());
-  h256.absorb(r_prm.data(), r_prm.size());
+  h256.absorb(k);
+  h256.absorb(r_prm);
   h256.finalize();
-  h256.digest(seskey.data());
+  h256.digest(seskey);
   h256.reset();
 }
 
@@ -169,11 +169,11 @@ decaps(std::span<const uint8_t, saber_utils::kem_ctlen<L, EP, ET>()> ctxt,
   saber_pke::decrypt<L, EQ, EP, ET, MU>(ctxt, sk, m);
 
   // step 3, 4
-  sha3_512::sha3_512 h512;
-  h512.absorb(m.data(), m.size());
-  h512.absorb(hash_pk.data(), hash_pk.size());
+  sha3_512::sha3_512_t h512;
+  h512.absorb(m);
+  h512.absorb(hash_pk);
   h512.finalize();
-  h512.digest(rk.data());
+  h512.digest(rk);
   h512.reset();
 
   // step 5
@@ -191,17 +191,17 @@ decaps(std::span<const uint8_t, saber_utils::kem_ctlen<L, EP, ET>()> ctxt,
   saber_utils::ct_sel_bytes<temp.size()>(c, temp, k, z);
 
   // step 8
-  sha3_256::sha3_256 h256;
-  h256.absorb(ctxt.data(), ctxt.size());
+  sha3_256::sha3_256_t h256;
+  h256.absorb(ctxt);
   h256.finalize();
-  h256.digest(r_prm.data());
+  h256.digest(r_prm);
   h256.reset();
 
   // step 13
-  h256.absorb(temp.data(), temp.size());
-  h256.absorb(r_prm.data(), r_prm.size());
+  h256.absorb(temp);
+  h256.absorb(r_prm);
   h256.finalize();
-  h256.digest(seskey.data());
+  h256.digest(seskey);
   h256.reset();
 }
 

--- a/include/pke.hpp
+++ b/include/pke.hpp
@@ -32,10 +32,10 @@ keygen(std::span<const uint8_t, seedBytes> seedA,  // step 1
   std::array<uint8_t, seedBytes> hashedSeedA{};
 
   // step 2
-  shake128::shake128 hasher;
-  hasher.absorb(seedA.data(), seedA.size());
+  shake128::shake128_t hasher;
+  hasher.absorb(seedA);
   hasher.finalize();
-  hasher.squeeze(hashedSeedA.data(), hashedSeedA.size());
+  hasher.squeeze(hashedSeedA);
   hasher.reset();
 
   // step 4, 5

--- a/include/poly_matrix.hpp
+++ b/include/poly_matrix.hpp
@@ -194,10 +194,10 @@ public:
     std::array<uint8_t, buf_blen> buf{};
     auto bufs = std::span<uint8_t, buf_blen>(buf);
 
-    shake128::shake128 hasher;
-    hasher.absorb(seed.data(), seed.size());
+    shake128::shake128_t hasher;
+    hasher.absorb(seed);
     hasher.finalize();
-    hasher.squeeze(buf.data(), buf.size());
+    hasher.squeeze(bufs);
     hasher.reset();
 
     for (size_t i = 0; i < rows * cols; i++) {
@@ -225,10 +225,10 @@ public:
     std::array<uint8_t, buf_blen> buf{};
     auto _buf = std::span<uint8_t, buf_blen>(buf);
 
-    shake128::shake128 hasher;
-    hasher.absorb(seed.data(), seed.size());
+    shake128::shake128_t hasher;
+    hasher.absorb(seed);
     hasher.finalize();
-    hasher.squeeze(_buf.data(), _buf.size());
+    hasher.squeeze(_buf);
     hasher.reset();
 
     for (size_t i = 0; i < rows; i++) {

--- a/include/prng.hpp
+++ b/include/prng.hpp
@@ -27,41 +27,39 @@ namespace prng {
 struct prng_t
 {
 private:
-  shake128::shake128 state;
+  shake128::shake128_t state;
 
 public:
   // Default one, exercise caution if considering to use it for sampling randomness.
   inline prng_t()
   {
-    uint8_t seed[32];
+    std::array<uint8_t, 32> seed{};
+    auto _seed = std::span(seed);
 
     // Read more @
     // https://en.cppreference.com/w/cpp/numeric/random/random_device/random_device
     std::random_device rd{};
 
     size_t off = 0;
-    while (off < sizeof(seed)) {
+    while (off < _seed.size()) {
       const uint32_t v = rd();
-      std::memcpy(seed + off, &v, sizeof(v));
+      std::memcpy(_seed.subspan(off, sizeof(v)).data(), &v, sizeof(v));
 
       off += sizeof(v);
     }
 
-    state.absorb(seed, sizeof(seed));
+    state.absorb(_seed);
     state.finalize();
   }
 
   // Preferred alternative, consider passing >= 32 -bytes random seed.
   inline explicit prng_t(std::span<const uint8_t> seed)
   {
-    state.absorb(seed.data(), seed.size());
+    state.absorb(seed);
     state.finalize();
   }
 
-  inline void read(std::span<uint8_t> bytes)
-  {
-    state.squeeze(bytes.data(), bytes.size());
-  }
+  inline void read(std::span<uint8_t> bytes) { state.squeeze(bytes); }
 };
 
 }


### PR DESCRIPTION
Update SHA3 dependency to latest commit https://github.com/itzmeanjan/sha3/commit/2228e43fe56bb0184311352bb9b94d2336ae4216. 

This change increases time required for performing `keygen`, `encaps` and `decaps`. Considering Saber KEM implementation at commit 3628f5a23f7eb03e9897e1d76eae41df27293bb6 as baseline while commit 1bf5a74c979b40c13cc2180b787a189872145af8 is contender implementation, we get 2-4% performance reduction. 

```bash
Benchmark                           Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------
lightsaber/keygen                +0.0453         +0.0453         40799         42647         40797         42644
lightsaber/encaps                +0.0313         +0.0313         60504         62400         60499         62395
lightsaber/decaps                +0.0228         +0.0228         77636         79408         77632         79402
saber/keygen                     +0.0314         +0.0314         87429         90178         87423         90172
saber/encaps                     +0.0346         +0.0347        116823        120867        116809        120857
saber/decaps                     +0.0223         +0.0223        142016        145187        142005        145178
firesaber/keygen                 +0.0281         +0.0281        154801        159151        154789        159137
firesaber/encaps                 +0.0239         +0.0239        193369        197989        193358        197978
firesaber/decaps                 +0.0201         +0.0201        227555        232126        227537        232109
OVERALL_GEOMEAN                  +0.0289         +0.0289             0             0             0             0
```